### PR TITLE
Clarify readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,70 @@
 
 # RSpec: Instance Doubles, Class Doubles, and Spies (BookOrder & Bookstore Edition)
 
-In this lesson, you'll master **verifying doubles**—`instance_double`, `class_double`, and `object_double`—plus **spies**. These tools help you write safer, more robust, and more maintainable tests by ensuring your doubles match the real objects they're standing in for, and by letting you verify that methods were called as expected. All examples use a BookOrder/Bookstore domain for clarity and realism.
+Welcome to an in-depth exploration of **verifying doubles** and **spies** in RSpec! In this lesson, you'll learn how to write safer, more maintainable tests using `instance_double`, `class_double`, `object_double`, and spies. All examples use a realistic BookOrder/Bookstore domain to help you understand these concepts in context.
+
+## Learning Objectives
+
+By the end of this lesson, you will be able to:
+
+- Explain the difference between regular doubles and verifying doubles
+- Use `instance_double` to create strict doubles for class instances
+- Use `class_double` to create strict doubles for class methods
+- Use `object_double` to create doubles based on real object instances
+- Implement spies to verify method calls after they happen
+- Choose the appropriate type of double for different testing scenarios
+
+---
+
+## The Problem with Regular Doubles
+
+Before we dive into verifying doubles, let's understand why they exist. Regular doubles (`double`) will let you stub *any* method—even ones that don't exist on the real object:
+
+```ruby
+# This works but is dangerous!
+order = double("BookOrder")
+allow(order).to receive(:nonexistent_method).and_return("oops!")
+```
+
+This can lead to:
+
+- False confidence in your tests
+- Broken code that passes tests
+- Maintenance nightmares when APIs change
+
+**Verifying doubles** solve this by only allowing you to stub methods that actually exist on the real class.
 
 ---
 
 ## What Are Verifying Doubles?
 
-Regular doubles will let you stub *any* method—even ones that don't exist on the real object. This can lead to false confidence and brittle tests. **Verifying doubles** (`instance_double`, `class_double`, and `object_double`) are stricter: they only let you stub or expect methods that actually exist on the real class or instance. If you try to stub a method that doesn't exist, your test will fail!
+**Verifying doubles** (`instance_double`, `class_double`, and `object_double`) are stricter versions of regular doubles. They verify that:
+
+1. The methods you stub actually exist on the real class
+2. The method signatures match (correct number of arguments)
+3. Your tests stay in sync with your actual code
+
+If you try to stub a method that doesn't exist, your test will fail immediately—and that's a good thing!
 
 ---
 
 ## Instance Doubles
 
-An `instance_double` is a strict test double for an instance of a class. It checks that the methods you stub or expect actually exist on the real class.
+An `instance_double` creates a strict test double that represents an **instance** of a class. It only allows you to stub methods that exist on the real class, helping catch typos and API changes early.
 
-### Basic Example of Instance Doubles
+### When to Use Instance Doubles
+
+Use `instance_double` when you want to:
+
+- Test interactions with an object without creating a real instance
+- Ensure your doubles stay in sync with the real class interface
+- Catch typos in method names during testing
+- Speed up tests by avoiding expensive object creation
+
+### Basic Example
 
 ```ruby
-# /spec/doubles_spec.rb
+# This creates a double that behaves like a BookOrder instance
 order = instance_double("BookOrder", place: :placed, status: :pending)
 expect(order.place).to eq(:placed)
 expect(order.status).to eq(:pending)
@@ -26,100 +72,214 @@ expect(order.status).to eq(:pending)
 
 **What happens?**
 
-If the `BookOrder` class has `place` and `status` methods, this passes. If not, RSpec raises an error: `BookOrder does not implement: place`.
+RSpec checks that `BookOrder` has `place` and `status` methods. If they exist, the test passes. If not, you get an error like: `BookOrder does not implement: place`.
 
-### Scenario: Catching Typos
+### Catching Typos Early
+
+This is one of the biggest benefits of verifying doubles:
 
 ```ruby
-order = instance_double("BookOrder", sttaus: :pending) # typo!
+# This will fail immediately!
+order = instance_double("BookOrder", sttaus: :pending) # typo in "status"
+# Error: BookOrder does not implement: sttaus
 ```
 
-This will fail with an error, helping you catch mistakes early.
+Without verifying doubles, this typo might go unnoticed until much later.
 
-### Scenario: Stubbing Multiple Methods
+### Stubbing Multiple Methods
 
 ```ruby
-order = instance_double("BookOrder", place: :placed, cancel: :cancelled, status: :pending)
+order = instance_double("BookOrder",
+  place: :placed,
+  cancel: :cancelled,
+  status: :pending
+)
+
 expect(order.cancel).to eq(:cancelled)
+expect(order.status).to eq(:pending)
 ```
 
 ---
 
 ## Class Doubles
 
-A `class_double` is a strict double for a class itself (for stubbing or expecting class methods).
+A `class_double` creates a strict double for a **class itself**, allowing you to stub or mock class methods (also called static methods). This is perfect when you need to test interactions with class-level functionality.
 
-### Basic Example of Class Doubles
+### When to Use Class Doubles
+
+Use `class_double` when you want to:
+
+- Stub class methods like `find`, `create`, or `all`
+- Test code that calls class methods without hitting a database
+- Ensure your class method calls are correct
+- Mock external services accessed through class methods
+
+### Basic Class Double Example
 
 ```ruby
+# This creates a double for the Bookstore class itself
 store = class_double("Bookstore", find: "Book: Ruby 101")
 expect(store.find("Ruby 101")).to eq("Book: Ruby 101")
 ```
 
 **What happens?**
 
-If the `Bookstore` class has a `find` class method, this passes. If not, RSpec raises an error: `Bookstore does not implement: .find`.
+RSpec verifies that `Bookstore` has a class method called `find`. If it doesn't exist, you get: `Bookstore does not implement: .find` (note the dot indicating a class method).
 
-### Scenario: Stubbing Multiple Class Methods
+### Real-World Scenario
+
+Imagine testing a service that finds books:
 
 ```ruby
-store = class_double("Bookstore", find: "Book: Ruby 101", all: ["Book: Ruby 101", "Book: RSpec Mastery"])
+class BookSearchService
+  def self.search_for(title)
+    book = Bookstore.find(title)
+    "Found: #{book}"
+  end
+end
+
+# In your test:
+it "searches for a book using Bookstore.find" do
+  store = class_double("Bookstore", find: "Book: Ruby 101")
+  allow(Bookstore).to receive(:find).and_return("Book: Ruby 101")
+
+  result = BookSearchService.search_for("Ruby 101")
+  expect(result).to eq("Found: Book: Ruby 101")
+end
+```
+
+### Stubbing Multiple Class Methods
+
+```ruby
+store = class_double("Bookstore",
+  find: "Book: Ruby 101",
+  all: ["Book: Ruby 101", "Book: RSpec Mastery"]
+)
+
+expect(store.find("Ruby 101")).to eq("Book: Ruby 101")
 expect(store.all).to include("Book: Ruby 101")
 ```
 
 ---
 
-## Spies
+## Object Doubles
 
-**Spies** let you check that a method was called, and with what arguments, *after* the fact. This is useful for verifying side effects or interactions between objects.
+An `object_double` creates a strict double based on a **specific object instance**. Unlike `instance_double` which uses the class name, `object_double` takes an actual object and ensures your double matches that specific object's interface.
 
-### Basic Example of Spies
+### When to Use Object Doubles
+
+Use `object_double` when you:
+
+- Have a specific object instance you want to double
+- Need to ensure your double matches a particular object's current state
+- Want to test against an object that might have been configured or modified
+
+### Basic Object Double Example
 
 ```ruby
-store = double("Bookstore").as_null_object
-store.order_book("Ruby 101", "Alice")
-expect(store).to have_received(:order_book).with("Ruby 101", "Alice")
+real_store = Bookstore.new
+store_double = object_double(real_store, order_book: "Order placed for Ruby 101 by Alice")
+expect(store_double.order_book("Ruby 101", "Alice")).to eq("Order placed for Ruby 101 by Alice")
 ```
 
-**What happens?**
+The double will only allow methods that exist on the `real_store` instance.
 
-The `as_null_object` call lets the double ignore unstubbed methods (so `order_book` doesn't raise an error). After calling `store.order_book(...)`, we check that it was called with the right arguments.
+---
 
-### Scenario: Spying on Real Objects
+## Spies: Verifying Method Calls After the Fact
 
-You can also spy on real objects using `allow(...).to receive` and `expect(...).to have_received`:
+**Spies** are a powerful testing pattern that lets you verify that methods were called *after* your code runs. This is particularly useful for testing side effects, logging, notifications, or any scenario where you care *that* something happened, not just *what* it returned.
+
+### Why Use Spies?
+
+Traditional mocks require you to set expectations *before* the code runs:
 
 ```ruby
-order = BookOrder.new("Ruby 101", "Alice")
-allow(order).to receive(:place).and_call_original
-order.place
-expect(order).to have_received(:place)
+# Traditional mock: expectation BEFORE the call
+expect(mailer).to receive(:send_email).with("alice@example.com")
+UserService.welcome_new_user("alice@example.com")
+```
+
+Spies let you verify *after* the call, which can make tests more readable:
+
+```ruby
+# Spy: verify AFTER the call
+UserService.welcome_new_user("alice@example.com")
+expect(mailer).to have_received(:send_email).with("alice@example.com")
+```
+
+### Setting Up Spies on Real Objects
+
+To spy on a real object, you use `allow(...).to receive(...)`:
+
+```ruby
+it "notifies customer when order is placed" do
+  store = Bookstore.new
+  # Set up the spy
+  allow(store).to receive(:notify_customer).and_call_original
+
+  # Execute the code you're testing
+  store.notify_customer("Alice", "Your book has shipped!")
+
+  # Verify the method was called correctly
+  expect(store).to have_received(:notify_customer).with("Alice", "Your book has shipped!")
+end
+```
+
+### Spying Without Changing Behavior
+
+The `and_call_original` ensures the real method still runs. If you want to spy without executing the real method:
+
+```ruby
+allow(store).to receive(:notify_customer) # method won't actually run
+store.notify_customer("Alice", "Your book has shipped!")
+expect(store).to have_received(:notify_customer).with("Alice", "Your book has shipped!")
+```
+
+### Spying on Multiple Calls
+
+Spies can verify multiple calls and their order:
+
+```ruby
+store = Bookstore.new
+allow(store).to receive(:notify_customer)
+
+store.notify_customer("Alice", "Order received")
+store.notify_customer("Alice", "Order shipped")
+
+expect(store).to have_received(:notify_customer).twice
+expect(store).to have_received(:notify_customer).with("Alice", "Order received").ordered
+expect(store).to have_received(:notify_customer).with("Alice", "Order shipped").ordered
 ```
 
 ---
 
-## More Scenarios & Edge Cases
+## Choosing the Right Tool
 
-- If you try to stub a method that doesn't exist on the real class, verifying doubles will fail (and that's a good thing!).
-- You can use verifying doubles with modules, too (`object_double`).
-- `object_double` is like `instance_double`, but verifies against a specific object instance (not just a class). Use it when you want to double a particular object, not just any instance of a class.
-- Spies can be used with both doubles and real objects.
-- `as_null_object` lets a double ignore unstubbed methods (useful for spies).
+Here's a quick guide for when to use each type of double:
+
+| Use Case | Tool | Example |
+|----------|------|---------|
+| Mock an instance of a class | `instance_double` | `instance_double("BookOrder", status: :pending)` |
+| Mock class methods | `class_double` | `class_double("Bookstore", find: "Book: Ruby 101")` |
+| Mock based on specific object | `object_double` | `object_double(real_store, order_book: "result")` |
+| Verify method was called | Spy | `expect(store).to have_received(:notify_customer)` |
 
 ---
 
 ## Getting Hands-On
 
-Ready to practice? Here’s how to get started:
+Ready to practice? Here's how to get started:
 
 1. **Fork and clone this repo to your own GitHub account.**
+
 2. **Install dependencies:**
 
     ```zsh
     bundle install
     ```
 
-3. **Run the specs:**
+3. **Run the specs to see the current state:**
 
     ```zsh
     bin/rspec
@@ -127,23 +287,35 @@ Ready to practice? Here’s how to get started:
 
 4. **Explore the code:**
 
-   - All lesson code uses the BookOrder and Bookstore domain (see `lib/` and `spec/doubles_spec.rb`).
-   - Review the examples for `instance_double`, `class_double`, `object_double`, and spies.
+   - Review `lib/book_order.rb` and `lib/bookstore.rb` to understand the domain
+   - Examine `spec/doubles_spec.rb` to see examples of all the concepts in action
+   - Notice how the pending specs guide you toward implementation
 
-5. **Implement the pending specs:**
+5. **Experiment with the concepts:**
 
-   - Open `spec/doubles_spec.rb` and look for specs marked as `pending`.
-   - Implement the real methods in `lib/book_order.rb` as needed so the pending specs pass.
+   - Try modifying the doubles in the specs to see validation errors
+   - Add new methods to the classes and create doubles for them
+   - Practice creating spies for different scenarios
 
-6. **Re-run the specs** to verify your changes!
+6. **Complete the pending specs:**
 
-**Challenge:** Try writing your own spec using a verifying double or a spy for a new method on BookOrder or Bookstore.
+   The specs marked as `pending` are already implemented in the classes, but the tests need to be uncommented. This simulates a common scenario where you have working code but need to add proper test coverage.
+
+---
+
+## Best Practices
+
+1. **Use verifying doubles by default** - They catch more errors and keep tests in sync with code
+2. **Prefer spies for side effects** - When you care that something happened, not what it returned
+3. **Use class doubles for external services** - Great for mocking APIs, databases, or third-party services
+4. **Keep doubles simple** - Don't recreate complex object hierarchies with doubles
+5. **Test the interaction, not the implementation** - Focus on what your code does, not how it does it
 
 ---
 
 ## What's Next?
 
-In the next lab, you'll get hands-on practice test-driving a Ruby service object using doubles and spies. This is your chance to apply verifying doubles and spies in a real-world scenario.
+Now that you understand verifying doubles and spies, you're ready to write more robust tests. In the next lesson, you'll apply these concepts to test-drive a real-world service object, dealing with external dependencies and complex interactions.
 
 ---
 
@@ -153,5 +325,4 @@ In the next lab, you'll get hands-on practice test-driving a Ruby service object
 - [RSpec: Class Doubles](https://relishapp.com/rspec/rspec-mocks/v/3-10/docs/verifying-doubles/class-doubles)
 - [RSpec: Object Doubles](https://relishapp.com/rspec/rspec-mocks/v/3-10/docs/verifying-doubles/object-doubles)
 - [RSpec: Spies](https://relishapp.com/rspec/rspec-mocks/v/3-10/docs/basics/spies)
-- [RSpec: as_null_object](https://relishapp.com/rspec/rspec-mocks/v/3-10/docs/basics/null-object-double)
 - [Better Specs: Doubles](https://www.betterspecs.org/#doubles)


### PR DESCRIPTION
This pull request significantly expands and restructures the `README.md` to provide a much more comprehensive and beginner-friendly guide to RSpec verifying doubles and spies, using the BookOrder/Bookstore domain. The new version introduces clearer learning objectives, in-depth explanations, practical scenarios, and best practices, making it easier for readers to understand when and how to use each type of double and spy.

Key improvements and additions:

**Major content expansion and reorganization:**
- Introduced a clear overview, learning objectives, and step-by-step explanations for `instance_double`, `class_double`, `object_double`, and spies, including practical scenarios and code examples.
- Added detailed explanations of the problems with regular doubles and the benefits of verifying doubles, with emphasis on catching errors early and maintaining test reliability.

**Practical guidance and best practices:**
- Added a "Choosing the Right Tool" section with a summary table to help readers decide which double or spy to use in different situations.
- Included a "Best Practices" section to guide users on effective usage patterns for doubles and spies.

**Hands-on instructions and next steps:**
- Expanded the hands-on section with clearer instructions for running and experimenting with the codebase, and clarified the process for completing pending specs.
- Updated the "What's Next?" section to set expectations for future labs and practical application.

**Reference links update:**
- Removed the reference to `as_null_object` from the external resources, streamlining the list of recommended readings.